### PR TITLE
Fix for #3078

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -542,7 +542,7 @@ def _human_to_bytes(number):
             return int(number[:-len(each)]) * (1024 ** i)
         i = i + 1
 
-    raise ValueError('Could not convert %s to integer' % (number,))
+    return int(number)
 
 
 def _ansible_facts(container_list):
@@ -1774,7 +1774,7 @@ def main():
             devices         = dict(default=None, type='list'),
             memory_limit    = dict(default=0),
             memory_swap     = dict(default=0),
-            cpu_shares      = dict(default=0),
+            cpu_shares      = dict(default=0, type='int'),
             docker_url      = dict(),
             use_tls         = dict(default=None, choices=['no', 'encrypt', 'verify']),
             tls_client_cert = dict(required=False, default=None, type='str'),


### PR DESCRIPTION
##### Issue Type:

 - Bugfix Pull Request

##### Plugin Name:

core/cloud/docker

##### Summary: 

Fixes casting issue with cpu_shares fact in docker.py.

##### Example:

```
TASK [foundation_installer : Install/run Docker Registry container] **********************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Could not convert 0 to integer"}
```

